### PR TITLE
HWE kernel selection, install_kvm, install_rackd flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,17 @@ resource "maas_instance" "maas_single_random_node" {
 }
 ```
 
+### Select ubuntu kernel release (HWE kernel version)
+Useful for choosing a particular kernel release train builds
+```
+resource "maas_instance" "maas_single_random_node" {
+    count = 1
+    distro_series = "bionic"
+    hwe_kernel = "hwe-18.04" 
+}
+```
+
+
 ## Erasing disks on node release
 
 Maas provides an option to erase the node's disk when releasing the system. By default it will not alter the disk.
@@ -206,6 +217,17 @@ resource "maas_instance" "maas_single_random_node" {
     release_erase_quick = true
 }
 ```
+
+### Build kvm server
+
+```
+resource "maas_instance" "maas_single_random_node" {
+    count = 1
+
+    install_kvm = true
+}
+```
+
 
 If there are conflicting options, such as enabling both secure and quick erase, this is how the Maas API deals with conflicts.
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,16 @@ resource "maas_instance" "maas_single_random_node" {
 }
 ```
 
+### Build rack controller
+
+```
+resource "maas_instance" "maas_single_random_node" {
+    count = 1
+
+    install_rackd = true
+}
+```
+
 
 If there are conflicting options, such as enabling both secure and quick erase, this is how the Maas API deals with conflicts.
 

--- a/config.go
+++ b/config.go
@@ -17,7 +17,7 @@ type NodeInfo struct {
 	cpu_count     uint16
 	architecture  string
 	distro_series string
-	hwe_kernel	  string
+	hwe_kernel    string
 	memory        uint64
 	osystem       string
 	status        uint16
@@ -75,13 +75,6 @@ func toNodeInfo(nodeObject *gomaasapi.MAASObject) (*NodeInfo, error) {
 		log.Printf("[ERROR] [toNodeInfo] Unable to get the distro_series for node: %s\n", system_id)
 		return nil, err
 	}
-
-	hwe_kernel, err := nodeMap["hwe_kernel"].GetString()
-	if err != nil {
-		log.Printf("[ERROR] [toNodeInfo] Unable to get the hwe_kernel for node: %s\n", system_id)
-		return nil, err
-	}
-
 
 	memory_float, err := nodeMap["memory"].GetFloat64()
 	if err != nil {
@@ -143,7 +136,6 @@ func toNodeInfo(nodeObject *gomaasapi.MAASObject) (*NodeInfo, error) {
 		cpu_count:     uint16(cpu_count),
 		architecture:  architecture,
 		distro_series: distro_series,
-		hwe_kernel:    hwe_kernel,
 		memory:        memory,
 		osystem:       osystem,
 		status:        uint16(status),

--- a/config.go
+++ b/config.go
@@ -17,6 +17,7 @@ type NodeInfo struct {
 	cpu_count     uint16
 	architecture  string
 	distro_series string
+	hwe_kernel	  string
 	memory        uint64
 	osystem       string
 	status        uint16
@@ -74,6 +75,13 @@ func toNodeInfo(nodeObject *gomaasapi.MAASObject) (*NodeInfo, error) {
 		log.Printf("[ERROR] [toNodeInfo] Unable to get the distro_series for node: %s\n", system_id)
 		return nil, err
 	}
+
+	hwe_kernel, err := nodeMap["hwe_kernel"].GetString()
+	if err != nil {
+		log.Printf("[ERROR] [toNodeInfo] Unable to get the hwe_kernel for node: %s\n", system_id)
+		return nil, err
+	}
+
 
 	memory_float, err := nodeMap["memory"].GetFloat64()
 	if err != nil {
@@ -135,6 +143,7 @@ func toNodeInfo(nodeObject *gomaasapi.MAASObject) (*NodeInfo, error) {
 		cpu_count:     uint16(cpu_count),
 		architecture:  architecture,
 		distro_series: distro_series,
+		hwe_kernel:    hwe_kernel,
 		memory:        memory,
 		osystem:       osystem,
 		status:        uint16(status),

--- a/gmaw/gmaw.go
+++ b/gmaw/gmaw.go
@@ -36,3 +36,21 @@ res, err := gmaw.NewMachineManager(myMAAS).Deploy('your_sid', maas.MachineDeploy
 ```
 */
 package gmaw
+
+import (
+	"github.com/juju/gomaasapi"
+)
+
+// GetClient is a convenience function to create a new gomaasapi client.
+// It calls the NewAuthenticatedClient function with the provided credentials,
+// and calls NewMAAS() on the returned value to create the resulting MAASObject.
+// A non-nil error will be from GetAuthenticatedClient, and the returned client
+// can be used with the other types in this package.
+func GetClient(apiURL, apiKey, apiVersion string) (*gomaasapi.MAASObject, error) {
+	authClient, err := gomaasapi.NewAuthenticatedClient(
+		gomaasapi.AddAPIVersionToURL(apiURL, apiVersion), apiKey)
+	if err != nil {
+		return nil, err
+	}
+	return gomaasapi.NewMAAS(*authClient), nil
+}

--- a/gmaw/gmaw.go
+++ b/gmaw/gmaw.go
@@ -1,0 +1,38 @@
+/* gmaw is a wrapper (read: adapter) for github.com/juju/gomaasapi to make it
+compatible with the client interfaces defined in and expected by the adjacent
+maas package. See that package for conventions.
+
+While this package can be used alone, the exported types are designed to be
+consumed by their analog in the maas package. This package is just a vehicle
+for the maas package to access the MAAS API.
+
+Usage
+
+First, use the provided GetClient() or the gomaasapi equivalent to create a
+"global" gomaasapi.MAASObject for consumption by the types defined in this
+package. Next, use the New<T> function for the type that correlates to the
+endpoint you wish to call to return a usable type, and then start calling
+methods on the type to perform operations via your MAAS API.
+
+```
+// Get a gomaasapi client
+myMAAS, err := gmaw.GetClient("http://example/MAAS/", "supersecr3t", "2.0")
+if err != nil {
+	log.Fatal(err)
+}
+
+// Get the Machine endpoint
+myMachineClient := gmaw.NewMachine(myMAAS)
+
+// ...And use it with the maas package
+myChassis := maas.NewMachineManager('my_system_id', myMachineClient)
+if err := myChassis.Deploy(maas.MachineDeployParams{}); err != nil {
+	log.Fatal("Likely got a non-200 response from MAAS API")
+}
+
+// Or do it cowboy style
+yourMAAS, _ := gmaw.GetClient("http://example/MAAS/", "supersecr3t", "2.0")
+res, err := gmaw.NewMachineManager(myMAAS).Deploy('your_sid', maas.MachineDeployParams{})
+```
+*/
+package gmaw

--- a/gmaw/machine.go
+++ b/gmaw/machine.go
@@ -1,0 +1,59 @@
+package gmaw
+
+import (
+	"net/url"
+
+	"github.com/juju/gomaasapi"
+	"github.com/roblox/terraform-provider-maas/maas"
+)
+
+// Machine implements the maas.MachineFetcher interface.
+// It exposes the functionality of the MAAS Machine endpoint (eg machines/{systemid}),
+// and can be used with as many machines as desired since each method call takes the
+// systemID as a parameter. Multiple instances of this type are only necessary to
+// support multiple clients.
+type Machine struct {
+	client *gomaasapi.MAASObject
+}
+
+// NewMachine returns a pointer to a Machine.
+func NewMachine(client *gomaasapi.MAASObject) *Machine {
+	return &Machine{client: client}
+}
+
+// callPost returns the raw response from the MAAS API and any errors.
+// This method creates the appropriate MAASObject for the API call, invokes the
+// CallPost function, and returns the GetBytes() method of the response. It will
+// return a nil byte array if CallPost returns an error.
+func (m *Machine) callPost(systemID, op string, qsp url.Values) ([]byte, error) {
+	mc := m.client.GetSubObject("machines").GetSubObject(systemID)
+	res, err := mc.CallPost(op, qsp)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.GetBytes()
+}
+
+// Get fulfills the maas.MachineFetcher interface
+func (m *Machine) Get(systemID string) ([]byte, error) {
+	mc := m.client.GetSubObject("machines").GetSubObject(systemID)
+	res, err := mc.CallGet("", url.Values{})
+	if err != nil {
+		return nil, err
+	}
+
+	return res.GetBytes()
+}
+
+// Commission fulfills the maas.MachineFetcher interface
+func (m *Machine) Commission(systemID string, params maas.MachineCommissionParams) ([]byte, error) {
+	qsp := maas.ToQSP(params)
+	return m.callPost(systemID, "commission", qsp)
+}
+
+// Deploy fulfills the maas.MachineFetcher interface
+func (m *Machine) Deploy(systemID string, params maas.MachineDeployParams) ([]byte, error) {
+	qsp := maas.ToQSP(params)
+	return m.callPost(systemID, "deploy", qsp)
+}

--- a/gmaw/machines.go
+++ b/gmaw/machines.go
@@ -1,0 +1,48 @@
+package gmaw
+
+import (
+	"net/url"
+
+	"github.com/juju/gomaasapi"
+	"github.com/roblox/terraform-provider-maas/maas"
+)
+
+// Machines implements the maas.MachinesFetcher interface.
+type Machines struct {
+	client *gomaasapi.MAASObject
+}
+
+// NewMachines returns a pointer to a Machines.
+func NewMachines(client *gomaasapi.MAASObject) *Machines {
+	return &Machines{client: client}
+}
+
+// callPost returns the raw response from the MAAS API and any errors.
+// This method creates the appropriate MAASObject for the API call, invokes the
+// CallPost function, and returns the GetBytes() method of the response. It will
+// return a nil byte array if CallPost returns an error.
+func (m *Machines) callPost(op string, qsp url.Values) ([]byte, error) {
+	mc := m.client.GetSubObject("machines")
+	res, err := mc.CallPost(op, qsp)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.GetBytes()
+}
+
+// Allocate fulfills the maas.MachinesFetcher interface
+func (m *Machines) Allocate(params maas.MachinesAllocateParams) ([]byte, error) {
+	qsp := maas.ToQSP(params)
+	return m.callPost("allocate", qsp)
+}
+
+// Release fulfills the  maas.MachinesFetcher interface
+func (m *Machines) Release(systemIDs []string, comment string) error {
+	var qsp url.Values
+	for _, val := range systemIDs {
+		qsp.Add("system_id", val)
+	}
+	_, err := m.callPost("release", qsp)
+	return err
+}

--- a/maas/blockdevice.go
+++ b/maas/blockdevice.go
@@ -1,0 +1,15 @@
+package maas
+
+// BlockDevice represents the Block Device endpoint
+// NOTE: This is only a partial representation of the endpoint.
+type BlockDevice struct {
+	BlockSize int
+	ID        int
+	IDPath    string
+	Model     string
+	Name      string
+	Path      string
+	Serial    string
+	Size      int
+	Tags      []string
+}

--- a/maas/maas.go
+++ b/maas/maas.go
@@ -77,3 +77,54 @@ have a systemID string parameter that maps to the variable part of the URL. Each
 method will return the raw JSON response from the server as well as an error.
 */
 package maas
+
+import (
+	"fmt"
+	"net/url"
+	"reflect"
+	"strings"
+)
+
+// ToQSP represents a struct as query string parameters.
+// Given a struct value as input, it will add each field to a url.Values to be
+// printed in the form field=val. Elements of array values are handled via Add().
+//
+// The behavior of field names is similar to that of the json package: names are
+// converted to lower case, the value of a json struct tag will be used if present,
+// and the field will be excluded if it has a json tag of "-". Field values are
+// printed with fmt.Sprint() to create a string representation; this will work
+// properly for simple data types such as int and string.
+//
+// The function will panic if the input is not a struct, inlcuding on a pointer
+// to a struct. As this function relies heavily on reflection, it may panic under
+// other circumstances as well. It is only expected to work with simple structs
+// that represent query string parameters as Go types; other use cases are not
+// supported.
+func ToQSP(t interface{}) url.Values {
+	st := reflect.TypeOf(t)
+	sv := reflect.ValueOf(t)
+	qsp := url.Values{}
+
+	for i := 0; i < st.NumField(); i++ {
+		// Get the name of the QSP
+		key := st.Field(i).Name
+		if tag, ok := st.Field(i).Tag.Lookup("json"); ok {
+			if tag == "-" {
+				continue
+			}
+			key = tag
+		}
+		key = strings.ToLower(key)
+
+		// Parse out the values
+		field := sv.Field(i)
+		if field.Kind() == reflect.Array || field.Kind() == reflect.Slice {
+			for j := 0; j < field.Len(); j++ {
+				qsp.Add(key, fmt.Sprint(field.Index(j)))
+			}
+		} else {
+			qsp.Set(key, fmt.Sprint(field))
+		}
+	}
+	return qsp
+}

--- a/maas/maas.go
+++ b/maas/maas.go
@@ -1,0 +1,79 @@
+/* maas encapsulates a MAAS API client with thread safety, state management,
+Go types for resource data, and enhanced functionality for managing API calls.
+
+The types in this package are structured around providing a particular type
+of functionality for a given API endpoint: each endpoint will have three
+associated types. One type will be named after the endpoint, and maps
+directly to the underlying resource: the response to, for example a GET
+request to the API endpoint can be unmarshaled into this type. The  New<T>
+function for the type will handle this task. Next, each endpoint will have
+a <Name>Manager type to handle interacting with the endpoint. The manager
+provides the state management, additional safety, and any extra functionality
+around API calls. Finally, <Name>Fetcher defines the interface the API client
+must expose. More on this below.
+
+Note "endpoint" refers to the headings in the MAAS API Reference
+(https://docs.maas.io/2.5/en/api). This means, for example, there is a type
+for the Machines (/machines) endpoint as well as for the Machine
+(/machines/{system_id}) endpoint.
+
+Usage
+
+In general, a consumer of this package will interact with the Manager types
+for each endpoint. Each Manager's New<T> function will require a Fetcher:
+the Fetcher will perform the actual API calls, and return the response to
+the Manager. The types in the adjacent gmaw package implement the Fetcher
+interfaces defined in this package, and the documentation for that package
+demonstrates using those types in conjunction with Managers. In general,
+it looks something like this:
+
+```
+// Get something that fulfills the MachineFetcher interface
+machineFetcher := myapiclient.GetMachineFetcher()
+
+// Create the manager
+machineManager := maas.NewMachineManager('my_systemid', machineFetcher)
+
+// When we call Deploy() on the manager, the Fetcher makes the actual
+// API call and returns the result to the Manager.
+machineManager.Deploy(maas.MachineDeployParams{})
+```
+
+Defining Endpoint Types
+
+The type that represents the underlying resource is named after the consequent
+endpoint, so the "DHCP Snippet" endpoint would correlate to "DHCPSnippet". The
+type will be exported and contain exported fields for each field in the
+JSON representation of that resource (eg "name", "description", "enabled"),
+and the "node" field should be of type Node, where Node performs the same
+function for the Node endpoint. As these types serve no purpose other than
+to represent the state of a resource at a given time, they have no methods
+and no reason to use pointers. Use "json" struct tags where the JSON does
+not map directly to a PascalCase Golang name or implement the json.Marshaler
+and json.Unmarshaler interfaces. The values of these types' properties should
+never be altered; they are only exported to facilitate unmarshaling, and the
+types are only exported to save creating a public interface that mimics the type
+so other packages can consume the data.
+
+The Manager implements the State pattern, preserving a history of each recorded
+change in the underlying resource's state. As consumers of this package will
+interact exclusively with the Manager, not the Fetcher, its methods provide
+comprehensive access to the API endpoint, but may not map to the endpoint
+operations exactly. It provides convenience functions where necessary. The
+Manager provides thread safety via Mutexes where necessary, and performs
+checks on the current state of the resource before making non-idempotent
+API calls. It provides methods to access the current and historical state
+of the resource, as well as deltas, and also for determining whether long
+running API calls have completed.
+
+The Fetcher is an interface that contains methods that correlate to every
+an operation (?op=x) or HTTP verb where there is no operation for a given
+endpoint. For example, Machine.Get() correlates to `GET /machines/{system_id}`
+and Machine.Deploy() correlates to `POST /machines/{system_id}?op=deploy`. Due
+to the extreme variance in parameters between operations, most methods will
+accept a type that contains exported fields for each API parameter as a function
+parameter. A notable exception is the methods on the Machine type which also
+have a systemID string parameter that maps to the variable part of the URL. Each
+method will return the raw JSON response from the server as well as an error.
+*/
+package maas

--- a/maas/maas_test.go
+++ b/maas/maas_test.go
@@ -1,0 +1,125 @@
+package maas_test
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	. "github.com/roblox/terraform-provider-maas/maas"
+)
+
+type emptyStruct struct{}
+
+type simpleStruct struct {
+	Name       string
+	ID         int
+	unexported float64
+	Unsigned   uint8
+}
+
+type structWithTags struct {
+	PascalCase  string `json:"snake_case"`
+	ManyTags    string `json:"many_tags" sql:"-" computed:"true"`
+	NotIncluded string `json:"-"`
+}
+
+type structWithArrays struct {
+	Names []string
+	IDs   []string
+}
+
+var (
+	empty  = emptyStruct{}
+	simple = simpleStruct{
+		Name:       "Brian",
+		ID:         31,
+		unexported: 638.427,
+		Unsigned:   42,
+	}
+	simpleWithEmpties = simpleStruct{
+		Name:       "Frank",
+		unexported: 12,
+	}
+	tags = structWithTags{
+		PascalCase:  "always",
+		ManyTags:    "sure",
+		NotIncluded: "never",
+	}
+	arrays = structWithArrays{
+		Names: []string{"Robin", "Little John", "Mervyn"},
+		IDs:   []string{"Hood", "?", "Sheriff of Rottingham"},
+	}
+	arraysSortOf = structWithArrays{
+		Names: []string{"None"},
+		IDs:   []string{},
+	}
+)
+
+var (
+	emptyVals             = url.Values{}
+	simpleVals url.Values = map[string][]string{
+		"name":       []string{"Brian"},
+		"id":         []string{"31"},
+		"unexported": []string{"638.427"},
+		"unsigned":   []string{"42"},
+	}
+	simpleWEVals url.Values = map[string][]string{
+		"name":       []string{"Frank"},
+		"id":         []string{"0"},
+		"unexported": []string{"12"},
+		"unsigned":   []string{"0"},
+	}
+	tagsVals url.Values = map[string][]string{
+		"snake_case": []string{"always"},
+		"many_tags":  []string{"sure"},
+	}
+	arraysVals url.Values = map[string][]string{
+		"names": []string{"Robin", "Little John", "Mervyn"},
+		"ids":   []string{"Hood", "?", "Sheriff of Rottingham"},
+	}
+	arraysSOVals url.Values = map[string][]string{
+		"names": []string{"None"},
+	}
+)
+
+func TestToQSP(t *testing.T) {
+	tests := []struct {
+		name  string
+		input interface{}
+		want  url.Values
+	}{
+		{name: "empty", input: empty, want: emptyVals},
+		{name: "simple", input: simple, want: simpleVals},
+		{name: "simple with empties", input: simpleWithEmpties, want: simpleWEVals},
+		{name: "json", input: tags, want: tagsVals},
+		{name: "arrays", input: arrays, want: arraysVals},
+		{name: "tricky arrays", input: arraysSortOf, want: arraysSOVals},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ToQSP(tc.input)
+			diff := cmp.Diff(tc.want, got)
+			if diff != "" {
+				t.Fatalf(diff)
+			}
+		})
+	}
+}
+
+func ExampleToQSP() {
+	type whatev struct {
+		Foo int `json:"bar"`
+		Baz string
+		bat int
+	}
+	data := whatev{
+		Foo: 42,
+		Baz: "hello",
+		bat: 10,
+	}
+	res := ToQSP(data)
+	fmt.Println(res.Encode()) // Prints bar=42&bat=10&baz=hello
+}

--- a/maas/machine.go
+++ b/maas/machine.go
@@ -51,6 +51,7 @@ type Machine struct {
 	UserData               string
 	HWEKernel              string
 	Comment                string
+	InstallKVM             bool
 }
 
 // NewMachine converts a MAAS API JSON response into a Golang representation

--- a/maas/machine.go
+++ b/maas/machine.go
@@ -181,5 +181,5 @@ type MachineDeployParams struct {
 	BridgeFD     int
 	Comment      string
 	InstallRackD bool `json:"install_rackd"`
-	InstallKVM   bool
+	InstallKVM   bool `json:"install_kvm"`
 }

--- a/maas/machine.go
+++ b/maas/machine.go
@@ -1,0 +1,12 @@
+package maas
+
+// MachineFetcher is the interface that API clients must implement.
+type MachineFetcher interface {
+	Get(string) ([]byte, error)
+	Commission(string, MachineCommissionParams) ([]byte, error)
+	Deploy(string, MachineDeployParams) ([]byte, error)
+}
+
+type MachineCommissionParams struct{}
+
+type MachineDeployParams struct{}

--- a/maas/machine.go
+++ b/maas/machine.go
@@ -1,5 +1,27 @@
 package maas
 
+import "encoding/json"
+
+type Machine struct {
+	SystemID string `json:"system_id"`
+	Hostname string
+	// url           string What is this?
+	PowerState   string `json:"power_state"`
+	CpuCount     int    `json:"cpu_count"`
+	Architecture string `optional:"true" forceNew:"true"`
+	DistroSeries string `json:"distro_series"`
+	Memory       int
+	OSystem      string
+	Status       int
+	TagNames     []string `json:"tag_names"`
+	// data          map[string]interface{}
+}
+
+func NewMachine(data []byte) (m Machine, err error) {
+	err = json.Unmarshal(data, &m)
+	return
+}
+
 // MachineFetcher is the interface that API clients must implement.
 type MachineFetcher interface {
 	Get(string) ([]byte, error)

--- a/maas/machine.go
+++ b/maas/machine.go
@@ -2,6 +2,13 @@ package maas
 
 import "encoding/json"
 
+// - MachineManager needs a mutex, and
+// - A proper Caretaker might be necessary here to ease the hackery in Machines.Allocate()
+// - There needs to be a way to merge two Machines (ie the one from Allocate) if they have the same SystemID
+// - Need an Update() function to update the machine with the given systemID
+// - Might make sense to expose a function to create a machine with the interface mentioned above
+// - Make an abstract factory so the consumer of this package doesn't have to instantiate each type by hand
+
 type Machine struct {
 	SystemID string `json:"system_id"`
 	Hostname string
@@ -20,6 +27,63 @@ type Machine struct {
 func NewMachine(data []byte) (m Machine, err error) {
 	err = json.Unmarshal(data, &m)
 	return
+}
+
+type MachineManager struct {
+	state  []Machine
+	client MachineFetcher
+}
+
+func NewMachineManager(systemID string, client MachineFetcher) (*MachineManager, error) {
+	res, err := client.Get(systemID)
+	if err != nil {
+		return nil, err
+	}
+	m, err := NewMachine(res)
+	if err != nil {
+		return nil, err
+	}
+	return &MachineManager{
+		state:  []Machine{m},
+		client: client,
+	}, nil
+}
+
+func (m *MachineManager) Current() Machine {
+	return m.state[len(m.state)-1]
+}
+
+func (m *MachineManager) append(current Machine) *MachineManager {
+	m.state = append(m.state, current)
+	return m
+}
+
+func (m *MachineManager) appendBytes(data []byte) error {
+	next, err := NewMachine(data)
+	if err == nil {
+		m.append(next)
+	}
+	return err
+}
+
+func (m *MachineManager) SystemID() string {
+	return m.Current().SystemID
+}
+
+func (m *MachineManager) Commission(params MachineCommissionParams) error {
+	res, err := m.client.Commission(m.SystemID(), params)
+	if err == nil {
+		err = m.appendBytes(res)
+	}
+	return err
+}
+
+func (m *MachineManager) Deploy(params MachineDeployParams) error {
+	res, err := m.client.Deploy(m.SystemID(), params)
+	if err == nil {
+		err = m.appendBytes(res)
+	}
+	return err
 }
 
 // MachineFetcher is the interface that API clients must implement.

--- a/maas/machine.go
+++ b/maas/machine.go
@@ -1,39 +1,76 @@
 package maas
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"sync"
+)
 
-// - MachineManager needs a mutex, and
 // - A proper Caretaker might be necessary here to ease the hackery in Machines.Allocate()
 // - There needs to be a way to merge two Machines (ie the one from Allocate) if they have the same SystemID
-// - Need an Update() function to update the machine with the given systemID
-// - Might make sense to expose a function to create a machine with the interface mentioned above
 // - Make an abstract factory so the consumer of this package doesn't have to instantiate each type by hand
+// - Convert error responses in gmaw to their "real" analog in juju/errors (why didn't they use this?)
 
-type Machine struct {
-	SystemID string `json:"system_id"`
-	Hostname string
-	// url           string What is this?
-	PowerState   string `json:"power_state"`
-	CpuCount     int    `json:"cpu_count"`
-	Architecture string `optional:"true" forceNew:"true"`
-	DistroSeries string `json:"distro_series"`
-	Memory       int
-	OSystem      string
-	Status       int
-	TagNames     []string `json:"tag_names"`
-	// data          map[string]interface{}
+// MACAddress is used by the Machine endpoint
+type MACAddress struct {
+	MACAddress  string
+	ResourceURI string
 }
 
+// Machine represents the Machine endpoint
+type Machine struct {
+	Architecture           string
+	BootType               string
+	CPUCount               int
+	DisableIPv4            bool `json:"disable_ipv4"`
+	DistroSeries           string
+	Hostname               string
+	DeployHostname         string
+	DeployTags             []string
+	Tags                   []string
+	ReleaseErase           bool
+	ReleaseEraseSecure     bool
+	ReleaseEraseQuick      bool
+	IPAddresses            []string
+	MACAddressSet          []MACAddress
+	Memory                 int
+	Netboot                bool
+	OSystem                string
+	Owner                  string
+	PhysicalBlockDeviceSet []BlockDevice `json:"physicalblockdevice_set"`
+	PowerState             string
+	PowerType              string
+	PXEMac                 []MACAddress
+	ResourceURI            string
+	Routers                []string
+	Status                 int
+	Storage                int
+	SwapSize               int
+	SystemID               string
+	TagNames               []string
+	Zone                   []Zone
+	UserData               string
+	HWEKernel              string
+	Comment                string
+}
+
+// NewMachine converts a MAAS API JSON response into a Golang representation
 func NewMachine(data []byte) (m Machine, err error) {
 	err = json.Unmarshal(data, &m)
 	return
 }
 
+// MachineManager contains functionality for manipulating the Machine endpoint.
+// A MachineManager represents a single machine, as does the API endpoint.
 type MachineManager struct {
 	state  []Machine
 	client MachineFetcher
+	mutex  sync.RWMutex
 }
 
+// NewMachineManager creates a new MachineManager.
+// It attempts to fetch the current state of the machine with the given systemID,
+// and will return the API client's error if it is not successful. It will also return
+// an error from NewMachine if the response cannot successfully be parsed as a Machine.
 func NewMachineManager(systemID string, client MachineFetcher) (*MachineManager, error) {
 	res, err := client.Get(systemID)
 	if err != nil {
@@ -46,9 +83,11 @@ func NewMachineManager(systemID string, client MachineFetcher) (*MachineManager,
 	return &MachineManager{
 		state:  []Machine{m},
 		client: client,
+		mutex:  sync.RWMutex{},
 	}, nil
 }
 
+// Current returns the most current known state of the machine.
 func (m *MachineManager) Current() Machine {
 	return m.state[len(m.state)-1]
 }
@@ -66,11 +105,16 @@ func (m *MachineManager) appendBytes(data []byte) error {
 	return err
 }
 
+// SystemID returns the machine's systemID.
 func (m *MachineManager) SystemID() string {
 	return m.Current().SystemID
 }
 
+// Commission calls the commission operation on the API.
 func (m *MachineManager) Commission(params MachineCommissionParams) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
 	res, err := m.client.Commission(m.SystemID(), params)
 	if err == nil {
 		err = m.appendBytes(res)
@@ -78,12 +122,34 @@ func (m *MachineManager) Commission(params MachineCommissionParams) error {
 	return err
 }
 
+// Deploy calls the deploy operation on the API.
 func (m *MachineManager) Deploy(params MachineDeployParams) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
 	res, err := m.client.Deploy(m.SystemID(), params)
 	if err == nil {
 		err = m.appendBytes(res)
 	}
 	return err
+}
+
+// Update fetches and returns the current state of the machine.
+func (m *MachineManager) Update() (ma Machine, err error) {
+	ma, err = m.update()
+	if err == nil {
+		m.append(ma)
+	}
+	return
+}
+
+func (m *MachineManager) update() (ma Machine, err error) {
+	var res []byte
+	res, err = m.client.Get(m.SystemID())
+	if err == nil {
+		ma, err = NewMachine(res)
+	}
+	return
 }
 
 // MachineFetcher is the interface that API clients must implement.
@@ -93,6 +159,26 @@ type MachineFetcher interface {
 	Deploy(string, MachineDeployParams) ([]byte, error)
 }
 
-type MachineCommissionParams struct{}
+// MachineCommissionParams enumerates the parameters for the commission operation
+type MachineCommissionParams struct {
+	EnableSSH            int
+	SkipBMCConfig        int
+	SkipNetworking       int
+	SkipStorage          int
+	CommissioningScripts string
+	TestingScripts       string
+}
 
-type MachineDeployParams struct{}
+// MachineDeployParams enumerates the parameters for the deploy operation
+type MachineDeployParams struct {
+	UserData     string
+	DistroSeries string
+	HWEKernel    string
+	AgentName    string
+	BridgeAll    bool
+	BridgeSTP    bool
+	BridgeFD     int
+	Comment      string
+	InstallRackD bool `json:"install_rackd"`
+	InstallKVM   bool
+}

--- a/maas/machines.go
+++ b/maas/machines.go
@@ -1,0 +1,77 @@
+package maas
+
+type Machines []Machine
+
+type MachinesManager struct {
+	client MachinesFetcher
+}
+
+func NewMachinesManager(client MachinesFetcher) *MachinesManager {
+	return &MachinesManager{client: client}
+}
+
+func (m *MachinesManager) Allocate(params MachinesAllocateParams) (ma Machine, err error) {
+	var res []byte
+	res, err = m.client.Allocate(params)
+	if err == nil {
+		ma, err = NewMachine(res)
+	}
+	return
+}
+
+func (m *MachinesManager) Release(ms []*MachineManager, comment string) error {
+	var ids []string
+	for _, val := range ms {
+		ids = append(ids, val.SystemID())
+	}
+	return m.client.Release(ids, comment)
+}
+
+type MachinesParams struct {
+	Hostname   []string
+	MACAddress []string
+	ID         []string
+	Domain     string
+	Zone       string
+	AgentName  string
+	Pool       []string
+}
+
+// MachinesAllocateParams enumerates the options for the allocate operation.
+type MachinesAllocateParams struct {
+	Name             string
+	SystemID         string
+	Arch             string
+	CPUCount         int
+	Mem              int
+	Tags             []string
+	NotTags          []string
+	Zone             string
+	NotInZone        []string
+	Pool             string
+	NotInPool        []string
+	Pod              string
+	NotPod           string
+	PodType          string
+	NotPodType       string
+	Subnets          []string
+	NotSubnets       []string
+	Storage          []string
+	Interfaces       string
+	Fabrics          []string
+	NotFabrics       []string
+	FabricClasses    []string
+	NotFabricClasses []string
+	AgentName        string
+	Comment          string
+	BridgeAll        bool
+	BridgeSTP        bool
+	BridgeFD         int
+	DryRun           bool
+	Verbose          bool
+}
+
+type MachinesFetcher interface {
+	Allocate(params MachinesAllocateParams) ([]byte, error)
+	Release(systemId []string, comment string) error
+}

--- a/maas/machines.go
+++ b/maas/machines.go
@@ -1,15 +1,19 @@
 package maas
 
+// Machines represents the Machines endpoint
 type Machines []Machine
 
+// MachinesManager
 type MachinesManager struct {
 	client MachinesFetcher
 }
 
+// NewMachineManager
 func NewMachinesManager(client MachinesFetcher) *MachinesManager {
 	return &MachinesManager{client: client}
 }
 
+// Allocate calls the allocate operation
 func (m *MachinesManager) Allocate(params MachinesAllocateParams) (ma Machine, err error) {
 	var res []byte
 	res, err = m.client.Allocate(params)
@@ -19,14 +23,12 @@ func (m *MachinesManager) Allocate(params MachinesAllocateParams) (ma Machine, e
 	return
 }
 
-func (m *MachinesManager) Release(ms []*MachineManager, comment string) error {
-	var ids []string
-	for _, val := range ms {
-		ids = append(ids, val.SystemID())
-	}
-	return m.client.Release(ids, comment)
+// Release calls the release operation.
+func (m *MachinesManager) Release(systemIDs []string, comment string) error {
+	return m.client.Release(systemIDs, comment)
 }
 
+// MachinesParams enumerates the options for the GET operation
 type MachinesParams struct {
 	Hostname   []string
 	MACAddress []string
@@ -71,6 +73,7 @@ type MachinesAllocateParams struct {
 	Verbose          bool
 }
 
+// MachinesFetcher is the interface that API Clients must implement
 type MachinesFetcher interface {
 	Allocate(params MachinesAllocateParams) ([]byte, error)
 	Release(systemId []string, comment string) error

--- a/maas/node.go
+++ b/maas/node.go
@@ -1,0 +1,43 @@
+package maas
+
+// NodeStatus correlates to a Node Status code returned from the MAAS API.
+type NodeStatus int
+
+// The statuses are defined in src/maasserver/enum.py as of 06-2018, which can
+// be found at https://github.com/maas/maas/blob/master/src/maasserver/enum.py
+// The definitions are in `class NODE_STATUS`, which starts on L48 right now.
+// The statuses map to sequential ints, hence the iota - if a status is added or
+// changed, presumably they will maintain the sequential numbering. This way we only
+// have to maintain the correct order instead of having to ensure each value is
+// mapped correctly.
+// NodeStatusDefault, defined at the bottom, is an exception - it has the same
+// value as NodeStatusNew.
+// There are some smoke tests in node_test.go to verify some of the more
+// relevant statuses such as "commissioning" and "deployed".
+const (
+	NodeStatusNew NodeStatus = iota
+	NodeStatusCommissioning
+	NodeStatusFailedCommissioning
+	NodeStatusMissing
+	NodeStatusReady
+	NodeStatusReserved
+	NodeStatusDeployed
+	NodeStatusRetired
+	NodeStatusBroken
+	NodeStatusDeploying
+	NodeStatusAllocated
+	NodeStatusFailedDeployment
+	NodeStatusReleasing
+	NodeStatusFailedReleasing
+	NodeStatusDiskErasing
+	NodeStatusFailedDiskErasing
+	NodeStatusRescueMode
+	NodeStatusEnteringRescureMode
+	NodeStatusFailedEnteringRescueMode
+	NodeStatusExitingRescueMode
+	NodeStatusFailedExitingRescueMode
+	NodeStatusTesting
+	NodeStatusFailedTesting
+
+	NodeStatusDefault NodeStatus = 0
+)

--- a/maas/node_test.go
+++ b/maas/node_test.go
@@ -1,0 +1,33 @@
+package maas_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	. "github.com/roblox/terraform-provider-maas/maas"
+)
+
+func TestNodeStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		got  NodeStatus
+		want NodeStatus
+	}{
+		{name: "new", got: NodeStatusNew, want: 0},
+		{name: "default", got: NodeStatusDefault, want: 0},
+		{name: "commissioning", got: NodeStatusCommissioning, want: 1},
+		{name: "ready", got: NodeStatusReady, want: 4},
+		{name: "deployed", got: NodeStatusDeployed, want: 6},
+		{name: "deploying", got: NodeStatusDeploying, want: 9},
+		{name: "allocated", got: NodeStatusAllocated, want: 10},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			diff := cmp.Diff(tc.want, tc.got)
+			if diff != "" {
+				t.Fatalf(diff)
+			}
+		})
+	}
+}

--- a/maas/zone.go
+++ b/maas/zone.go
@@ -1,0 +1,9 @@
+package maas
+
+// Zone represents the Zone endpoint
+type Zone struct {
+	ID          int
+	Name        string
+	Description string
+	ResourceURI string
+}

--- a/maas_client.go
+++ b/maas_client.go
@@ -148,7 +148,7 @@ func nodeDo(maas *gomaasapi.MAASObject, system_id string, action string, params 
 
 	_, err = nodeObject.CallPost(action, params)
 	if err != nil {
-		log.Printf("[ERROR] [nodeDo] Unable to perform action (%s) on node (%s).  Failed withh error (%s)\n", action, system_id, err)
+		log.Printf("[ERROR] [nodeDo] Unable to perform action (%s) on node (%s).  Failed with error (%s)\n", action, system_id, err)
 		return err
 	}
 	return nil

--- a/maas_instance.go
+++ b/maas_instance.go
@@ -56,6 +56,16 @@ func resourceMAASInstanceCreate(d *schema.ResourceData, meta interface{}) error 
 		node_params.Add("distro_series", distro_series.(string))
 	}
 
+	// get hwe_kernel if defined
+	if hwe_kernel, ok := d.GetOk("hwe_kernel"); ok {
+		node_params.Add("hwe_kernel", hwe_kernel.(string))
+	}
+
+	// install kvm and register the server as a kvm server if requested
+	if install_kvm, ok := d.GetOk("install_kvm"); ok {
+		node_params.Add("install_kvm", strconv.FormatBool(install_kvm.(bool)))
+	}
+
 	if err := nodeDo(meta.(*Config).MAASObject, d.Id(), "deploy", node_params); err != nil {
 		log.Printf("[ERROR] [resourceMAASInstanceCreate] Unable to power up node: %s\n", d.Id())
 		// unable to perform action, release the node

--- a/maas_instance.go
+++ b/maas_instance.go
@@ -67,6 +67,12 @@ func resourceMAASInstanceCreate(d *schema.ResourceData, meta interface{}) error 
 		node_params.Add("install_kvm", strconv.FormatBool(true))
 	}
 
+	// install rackd if requested
+	if install_rackd, ok := d.GetOk("install_rackd"); ok {
+		log.Printf("[INFO] Adding maas rack controller packages: %s", install_rackd)
+		node_params.Add("install_rackd", strconv.FormatBool(true))
+	}
+
 	if err := nodeDo(meta.(*Config).MAASObject, d.Id(), "deploy", node_params); err != nil {
 		log.Printf("[ERROR] [resourceMAASInstanceCreate] Unable to power up node: %s\n", d.Id())
 		// unable to perform action, release the node

--- a/maas_instance.go
+++ b/maas_instance.go
@@ -63,7 +63,8 @@ func resourceMAASInstanceCreate(d *schema.ResourceData, meta interface{}) error 
 
 	// install kvm and register the server as a kvm server if requested
 	if install_kvm, ok := d.GetOk("install_kvm"); ok {
-		node_params.Add("install_kvm", strconv.FormatBool(install_kvm.(bool)))
+		log.Printf("[INFO] Adding KVM packages and configuration: %s", install_kvm)
+		node_params.Add("install_kvm", strconv.FormatBool(true))
 	}
 
 	if err := nodeDo(meta.(*Config).MAASObject, d.Id(), "deploy", node_params); err != nil {

--- a/maas_resource.go
+++ b/maas_resource.go
@@ -97,7 +97,14 @@ func resourceMAASInstance() *schema.Resource {
 			},
 
 			"install_kvm": {
-			    Type:     schema.TypeBool,
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: false,
+				Default:  false,
+			},
+
+			"install_rackd": {
+				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: false,
 				Default:  false,

--- a/maas_resource.go
+++ b/maas_resource.go
@@ -96,6 +96,13 @@ func resourceMAASInstance() *schema.Resource {
 				Default:  false,
 			},
 
+			"install_kvm": {
+			    Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: false,
+				Default:  false,
+			},
+
 			"ip_addresses": {
 				Type:     schema.TypeList,
 				Optional: true,

--- a/provider/blockdevice.go
+++ b/provider/blockdevice.go
@@ -1,0 +1,14 @@
+package provider
+
+// BlockDevice is used by the maas_instance resource
+type BlockDevice struct {
+	BlockSize int
+	ID        int
+	IDPath    string
+	Model     string
+	Name      string
+	Path      string
+	Serial    string
+	Size      int
+	Tags      []string
+}

--- a/provider/instance.go
+++ b/provider/instance.go
@@ -47,6 +47,7 @@ type Instance struct {
 	Zone                   []Zone        `optional:"true" type:"Set"`
 	UserData               string        `optional:"true" forcenew:"true" statefunc:"true"`
 	HWEKernel              string        `optional:"true" forcenew:"true"`
+	InstallKVM             bool          `optional:"true" forcenew:"true" default:"false"`
 	Comment                string        `optional:"true"`
 }
 

--- a/provider/instance.go
+++ b/provider/instance.go
@@ -1,0 +1,133 @@
+package provider
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"reflect"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/roblox/terraform-provider-maas/maas"
+)
+
+// MACAddress is used by the maas_instance resource
+type MACAddress maas.MACAddress
+
+// Instance models the maas_instance Terraform resource
+type Instance struct {
+	Architecture           string        `optional:"true" forcenew:"true"`
+	BootType               string        `optional:"true" forcenew:"true"`
+	CPUCount               int           `optional:"true" forcenew:"true"`
+	DisableIPv4            bool          `optional:"true" name:"disable_ipv4"`
+	DistroSeries           string        `optional:"true" forcenew:"true"`
+	Hostname               string        `optional:"true" forcenew:"true"`
+	DeployHostname         string        `optional:"true" forcenew:"true"`
+	DeployTags             []string      `optional:"true" forcenew:"true"`
+	Tags                   []string      `optional:"true" forcenew:"true"`
+	ReleaseErase           bool          `optional:"true" forcenew:"true" default:"false"`
+	ReleaseEraseSecure     bool          `optional:"true" forcenew:"true" default:"false"`
+	ReleaseEraseQuick      bool          `optional:"true" forcenew:"true" default:"false"`
+	IPAddresses            []string      `optional:"true" forcenew:"true"`
+	MACAddressSet          []MACAddress  `optional:"true" forcenew:"true"`
+	Memory                 int           `optional:"true" forcenew:"true"`
+	Netboot                bool          `optional:"true" forcenew:"true"`
+	OSystem                string        `optional:"true" forcenew:"true"`
+	Owner                  string        `optional:"true" forcenew:"true"`
+	PhysicalBlockDeviceSet []BlockDevice `optional:"true" forcenew:"true" name:"physicalblockdevice_set"`
+	PowerState             string        `optional:"true"`
+	PowerType              string        `optional:"true"`
+	PXEMac                 []MACAddress  `optional:"true" type:"Set"`
+	ResourceURI            string        `optional:"true" forcenew:"true"`
+	Routers                []string      `optional:"true"`
+	Status                 int           `optional:"true"`
+	Storage                int           `optional:"true"`
+	SwapSize               int           `optional:"true"`
+	SystemID               string        `optional:"true" forcenew:"true"`
+	TagNames               []string      `optional:"true"`
+	Zone                   []Zone        `optional:"true" type:"Set"`
+	UserData               string        `optional:"true" forcenew:"true" statefunc:"true"`
+	HWEKernel              string        `optional:"true" forcenew:"true"`
+	Comment                string        `optional:"true"`
+}
+
+// NewInstance creates a new instance from the value of the Terraform resource
+func NewInstance(resource *schema.ResourceData) Instance {
+	var instance Instance
+	st := reflect.TypeOf(instance)
+	sv := reflect.ValueOf(instance)
+
+	for i := 0; i < st.NumField(); i++ {
+		// Get the name of the schema field
+		key := st.Field(i).Name
+		if tag, ok := st.Field(i).Tag.Lookup("name"); ok {
+			if tag == "-" {
+				continue
+			}
+			key = tag
+		}
+		key = strings.ToLower(key)
+
+		// Set the value if one exists
+		if schemaVal, ok := resource.GetOk(key); ok {
+			field := sv.FieldByName(key)
+			reflectVal := reflect.ValueOf(schemaVal)
+			field.Set(reflectVal)
+		}
+	}
+	return instance
+}
+
+// FromMachine updates the instance to reflect the state of a Machine
+func (i Instance) FromMachine(m maas.Machine) Instance {
+	return i
+}
+
+// UpdateState updates the Terraform state to match the Instance state
+func (i Instance) UpdateState(resource *schema.ResourceData) {
+	st := reflect.TypeOf(i)
+	sv := reflect.ValueOf(i)
+
+	for i := 0; i < st.NumField(); i++ {
+		// Get the name of the schema field
+		key := st.Field(i).Name
+		if tag, ok := st.Field(i).Tag.Lookup("name"); ok {
+			if tag == "-" {
+				continue
+			}
+			key = tag
+		}
+		key = strings.ToLower(key)
+
+		// Set the value on the resource if it is not a zero value
+		field := sv.FieldByName(key)
+		if field.IsValid() {
+			resource.Set(key, field.Interface())
+		}
+	}
+}
+
+// AllocateParams creates parameters based on the current value of the Instance
+func (i Instance) AllocateParams() maas.MachinesAllocateParams {
+	var params maas.MachinesAllocateParams
+	if i.SystemID != "" {
+		params.SystemID = i.SystemID
+		return params
+	}
+	return params
+}
+
+// DeployParams creates parameters based on the current value of the Instance
+func (i Instance) DeployParams() maas.MachineDeployParams {
+	var params maas.MachineDeployParams
+	return params
+}
+
+func (i Instance) UserDataStateFunc(v interface{}) string {
+	switch v.(type) {
+	case string:
+		hash := sha1.Sum([]byte(v.(string)))
+		return hex.EncodeToString(hash[:])
+	default:
+		return ""
+	}
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1,0 +1,37 @@
+/* provider is a Terraform provider for MAAS.
+ */
+package provider
+
+import (
+	"github.com/roblox/terraform-provider-maas/gmaw"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func Provider() *schema.Provider {
+	return &schema.Provider{
+		Schema: map[string]*schema.Schema{
+			"api_key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The MAAS API key",
+			},
+			"api_url": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The MAAS server URL (eg http://1.2.3.4:80/MAAS)",
+			},
+			"api_version": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "2.0",
+				Description: "The MAAS API version (default 2.0)",
+			},
+		},
+		ConfigureFunc: providerConfigure,
+	}
+}
+
+func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	return gmaw.GetClient(d.Get("api_url").(string), d.Get("api_version").(string), d.Get("api_key").(string))
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -3,12 +3,13 @@
 package provider
 
 import (
+	"github.com/hashicorp/terraform/terraform"
 	"github.com/roblox/terraform-provider-maas/gmaw"
 
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-func Provider() *schema.Provider {
+func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"api_key": {
@@ -27,6 +28,9 @@ func Provider() *schema.Provider {
 				Default:     "2.0",
 				Description: "The MAAS API version (default 2.0)",
 			},
+		},
+		ResourcesMap: map[string]*schema.Resource{
+			"maas_instance": resourceInstance(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/provider/resource_instance.go
+++ b/provider/resource_instance.go
@@ -1,0 +1,75 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/juju/gomaasapi"
+	"github.com/roblox/terraform-provider-maas/gmaw"
+	"github.com/roblox/terraform-provider-maas/maas"
+)
+
+func resourceInstance() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceInstanceCreate,
+		Read:   resourceInstanceRead,
+		Update: resourceInstanceUpdate,
+		Delete: resourceInstanceDelete,
+
+		Schema: map[string]*schema.Schema{
+			"address": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceInstanceCreate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*gomaasapi.MAASObject)
+	var instance Instance
+
+	// Start by allocating the machine
+	machinesManager := maas.NewMachinesManager(gmaw.NewMachines(client))
+	ap := NewInstance(d).AllocateParams()
+	ma, err := machinesManager.Allocate(ap)
+	if err != nil {
+		return err
+	}
+
+	// Go ahead and set the ID if it allocates. That will add the resource to the state.
+	instance.FromMachine(ma).UpdateState(d)
+	d.SetId(ma.SystemID)
+
+	machineManager, err := maas.NewMachineManager(ma.SystemID, gmaw.NewMachine(client))
+	if err != nil {
+		return err
+	}
+
+	// Get node params and set them along with the deploy
+	dp := instance.FromMachine(machineManager.Current()).DeployParams()
+	if err := machineManager.Deploy(dp); err != nil {
+		machinesManager.Release([]string{machineManager.SystemID()}, "The deploy has broke")
+	}
+	return resourceInstanceRead(d, m)
+}
+
+func resourceInstanceRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*gomaasapi.MAASObject)
+	var instance Instance
+
+	machineManager, err := maas.NewMachineManager(d.Id(), gmaw.NewMachine(client))
+	if err != nil {
+		// FIXME if the error is that the system ID does not exist, d.SetId("")
+		return err
+	}
+
+	instance.FromMachine(machineManager.Current()).UpdateState(d)
+	return nil
+}
+
+func resourceInstanceUpdate(d *schema.ResourceData, m interface{}) error {
+	return resourceInstanceRead(d, m)
+}
+
+func resourceInstanceDelete(d *schema.ResourceData, m interface{}) error {
+	return nil
+}

--- a/provider/toschema.go
+++ b/provider/toschema.go
@@ -1,0 +1,86 @@
+package provider
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// ToSchemaMap transforms a struct{} into a map for a TF schema.Resource.
+// The first return value of this function is the Schema property of the
+// resource, and the function can handle recursion (ie nested structs).
+func ToSchemaMap(in interface{}) (map[string]*schema.Schema, error) {
+	st := reflect.TypeOf(in)
+	sch := make(map[string]*schema.Schema)
+
+	for i := 0; i < st.NumField(); i++ {
+		f := st.Field(i)
+		res, err := toSchema(f, in)
+		if err != nil {
+			return nil, err
+		}
+		sch[f.Name] = res
+	}
+	return sch, nil
+}
+
+// toSchema introspects a struct field.
+// The second parameter is the struct itself
+func toSchema(f reflect.StructField, in interface{}) (*schema.Schema, error) {
+	s := schema.Schema{}
+
+	// Figure out the schema.ValueType from the Go type
+	switch f.Type.Kind() {
+	case reflect.String:
+		s.Type = schema.TypeString
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		s.Type = schema.TypeInt
+	case reflect.Bool:
+		s.Type = schema.TypeBool
+	case reflect.Float32, reflect.Float64:
+		s.Type = schema.TypeFloat
+	}
+
+	// Add any attributes defined in struct tags
+	if val, ok := f.Tag.Lookup("required"); ok {
+		if val == "true" {
+			s.Required = true
+		} else {
+			s.Required = false
+		}
+	}
+	if val, ok := f.Tag.Lookup("optional"); ok {
+		if val == "true" {
+			s.Optional = true
+		} else {
+			s.Optional = false
+		}
+	}
+	if val, ok := f.Tag.Lookup("forcenew"); ok {
+		if val == "true" {
+			s.ForceNew = true
+		} else {
+			s.ForceNew = false
+		}
+	}
+	if val, ok := f.Tag.Lookup("computed"); ok {
+		if val == "true" {
+			s.Computed = true
+		} else {
+			s.Computed = false
+		}
+	}
+	if _, ok := f.Tag.Lookup("statefunc"); ok {
+		sv := reflect.ValueOf(in)
+		fn := sv.MethodByName(fmt.Sprintf("%sStateFunc", f.Name))
+		if fn != (reflect.Value{}) {
+			fi := fn.Interface()
+			s.StateFunc = fi.(schema.SchemaStateFunc)
+		} else {
+			return &s, fmt.Errorf("Cannot find method %sStateFunc", f.Name)
+		}
+	}
+
+	return &s, nil
+}

--- a/provider/zone.go
+++ b/provider/zone.go
@@ -1,0 +1,8 @@
+package provider
+
+// Zone is used by the maas_instance resource
+type Zone struct {
+	Name        string
+	Description string
+	ResourceURI string
+}

--- a/sample-host.json
+++ b/sample-host.json
@@ -1,0 +1,579 @@
+[
+    {
+        "blockdevice_set": [
+            {
+                "id_path": "/dev/disk/by-id/wwn-0x500a07511aee0940",
+                "size": 256060514304,
+                "block_size": 4096,
+                "tags": [
+                    "ssd",
+                    "sata"
+                ],
+                "path": "/dev/disk/by-dname/sda",
+                "name": "sda",
+                "system_id": "axpnhq",
+                "model": "MTFDDAK256TBN",
+                "serial": "18021AEE0940",
+                "partitions": [
+                    {
+                        "uuid": "ea843803-6f6e-449d-a577-c4311c1e8224",
+                        "size": 256053870592,
+                        "bootable": false,
+                        "tags": [],
+                        "path": "/dev/disk/by-dname/sda-part1",
+                        "system_id": "axpnhq",
+                        "used_for": "ext4 formatted filesystem mounted at /",
+                        "filesystem": {
+                            "fstype": "ext4",
+                            "label": "root",
+                            "uuid": "92d49f8d-eef8-4cbb-9ae0-2c91ac450264",
+                            "mount_point": "/",
+                            "mount_options": null
+                        },
+                        "type": "partition",
+                        "id": 361,
+                        "device_id": 25,
+                        "resource_uri": "/MAAS/api/2.0/nodes/axpnhq/blockdevices/25/partition/361"
+                    }
+                ],
+                "used_for": "MBR partitioned with 1 partition",
+                "available_size": 0,
+                "used_size": 256059113472,
+                "partition_table_type": "MBR",
+                "storage_pool": null,
+                "uuid": null,
+                "type": "physical",
+                "id": 25,
+                "filesystem": null,
+                "resource_uri": "/MAAS/api/2.0/nodes/axpnhq/blockdevices/25/"
+            }
+        ],
+        "status_action": "",
+        "status_name": "Deployed",
+        "testing_status_name": "Passed",
+        "cpu_count": 40,
+        "zone": {
+            "name": "default",
+            "description": "",
+            "id": 1,
+            "resource_uri": "/MAAS/api/2.0/zones/default/"
+        },
+        "current_testing_result_id": 1756,
+        "special_filesystems": [],
+        "hostname": "gs1-ac08-sjc1",
+        "hwe_kernel": "hwe-18.04",
+        "testing_status": 2,
+        "owner_data": {},
+        "architecture": "amd64/generic",
+        "disable_ipv4": false,
+        "distro_series": "bionic",
+        "commissioning_status": 2,
+        "cpu_test_status": -1,
+        "other_test_status": -1,
+        "locked": false,
+        "domain": {
+            "authoritative": true,
+            "ttl": null,
+            "name": "sjc1.roblox.local",
+            "is_default": true,
+            "resource_record_count": 142,
+            "id": 0,
+            "resource_uri": "/MAAS/api/2.0/domains/0/"
+        },
+        "status": 6,
+        "memory_test_status": -1,
+        "fqdn": "gs1-ac08-sjc1.sjc1.roblox.local",
+        "node_type_name": "Machine",
+        "memory_test_status_name": "Unknown",
+        "raids": [],
+        "pool": {
+            "name": "default",
+            "description": "Default pool",
+            "id": 0,
+            "resource_uri": "/MAAS/api/2.0/resourcepool/0/"
+        },
+        "storage_test_status_name": "Passed",
+        "tag_names": [],
+        "other_test_status_name": "Unknown",
+        "status_message": "Power state queried: on",
+        "storage_test_status": 2,
+        "hardware_info": {
+            "system_vendor": "Unknown",
+            "system_product": "Unknown",
+            "system_version": "Unknown",
+            "system_serial": "Unknown",
+            "cpu_model": "Unknown",
+            "mainboard_vendor": "Unknown",
+            "mainboard_product": "Unknown",
+            "mainboard_firmware_version": "Unknown",
+            "mainboard_firmware_date": "Unknown"
+        },
+        "address_ttl": null,
+        "interface_set": [
+            {
+                "discovered": [
+                    {
+                        "subnet": {
+                            "name": "ac08-sjc1 public",
+                            "vlan": {
+                                "vid": 0,
+                                "mtu": 1500,
+                                "dhcp_on": true,
+                                "external_dhcp": null,
+                                "relay_vlan": null,
+                                "space": "undefined",
+                                "name": "untagged",
+                                "secondary_rack": null,
+                                "fabric_id": 4,
+                                "fabric": "ac08-sjc1",
+                                "id": 5005,
+                                "primary_rack": "qbd6s7",
+                                "resource_uri": "/MAAS/api/2.0/vlans/5005/"
+                            },
+                            "cidr": "209.206.42.0/26",
+                            "rdns_mode": 2,
+                            "gateway_ip": "209.206.42.1",
+                            "dns_servers": [
+                                "10.164.0.48",
+                                "10.164.0.176",
+                                "10.164.0.112",
+                                "10.164.0.251",
+                                "10.164.1.60",
+                                "10.164.1.125"
+                            ],
+                            "allow_dns": true,
+                            "allow_proxy": true,
+                            "active_discovery": false,
+                            "managed": true,
+                            "id": 16,
+                            "space": "undefined",
+                            "resource_uri": "/MAAS/api/2.0/subnets/16/"
+                        },
+                        "ip_address": "209.206.42.11"
+                    }
+                ],
+                "parents": [],
+                "name": "enp5s0f0",
+                "system_id": "axpnhq",
+                "effective_mtu": 1500,
+                "tags": [],
+                "firmware_version": null,
+                "enabled": true,
+                "vlan": {
+                    "vid": 0,
+                    "mtu": 1500,
+                    "dhcp_on": true,
+                    "external_dhcp": null,
+                    "relay_vlan": null,
+                    "space": "undefined",
+                    "name": "untagged",
+                    "secondary_rack": null,
+                    "fabric_id": 4,
+                    "fabric": "ac08-sjc1",
+                    "id": 5005,
+                    "primary_rack": "qbd6s7",
+                    "resource_uri": "/MAAS/api/2.0/vlans/5005/"
+                },
+                "children": [],
+                "params": {},
+                "vendor": null,
+                "links": [
+                    {
+                        "id": 1299,
+                        "mode": "dhcp",
+                        "ip_address": "209.206.42.11",
+                        "subnet": {
+                            "name": "ac08-sjc1 public",
+                            "vlan": {
+                                "vid": 0,
+                                "mtu": 1500,
+                                "dhcp_on": true,
+                                "external_dhcp": null,
+                                "relay_vlan": null,
+                                "space": "undefined",
+                                "name": "untagged",
+                                "secondary_rack": null,
+                                "fabric_id": 4,
+                                "fabric": "ac08-sjc1",
+                                "id": 5005,
+                                "primary_rack": "qbd6s7",
+                                "resource_uri": "/MAAS/api/2.0/vlans/5005/"
+                            },
+                            "cidr": "209.206.42.0/26",
+                            "rdns_mode": 2,
+                            "gateway_ip": "209.206.42.1",
+                            "dns_servers": [
+                                "10.164.0.48",
+                                "10.164.0.176",
+                                "10.164.0.112",
+                                "10.164.0.251",
+                                "10.164.1.60",
+                                "10.164.1.125"
+                            ],
+                            "allow_dns": true,
+                            "allow_proxy": true,
+                            "active_discovery": false,
+                            "managed": true,
+                            "id": 16,
+                            "space": "undefined",
+                            "resource_uri": "/MAAS/api/2.0/subnets/16/"
+                        }
+                    }
+                ],
+                "product": null,
+                "type": "physical",
+                "id": 338,
+                "mac_address": "f4:e9:d4:bf:fb:50",
+                "resource_uri": "/MAAS/api/2.0/nodes/axpnhq/interfaces/338/"
+            },
+            {
+                "discovered": null,
+                "parents": [],
+                "name": "eno2",
+                "system_id": "axpnhq",
+                "effective_mtu": 1500,
+                "tags": [],
+                "firmware_version": null,
+                "enabled": true,
+                "vlan": null,
+                "children": [],
+                "params": "",
+                "vendor": null,
+                "links": [],
+                "product": null,
+                "type": "physical",
+                "id": 385,
+                "mac_address": "d0:94:66:3b:7b:2b",
+                "resource_uri": "/MAAS/api/2.0/nodes/axpnhq/interfaces/385/"
+            },
+            {
+                "discovered": null,
+                "parents": [],
+                "name": "eno1",
+                "system_id": "axpnhq",
+                "effective_mtu": 1500,
+                "tags": [],
+                "firmware_version": null,
+                "enabled": true,
+                "vlan": null,
+                "children": [],
+                "params": "",
+                "vendor": null,
+                "links": [],
+                "product": null,
+                "type": "physical",
+                "id": 384,
+                "mac_address": "d0:94:66:3b:7b:2a",
+                "resource_uri": "/MAAS/api/2.0/nodes/axpnhq/interfaces/384/"
+            },
+            {
+                "discovered": null,
+                "parents": [],
+                "name": "eno4",
+                "system_id": "axpnhq",
+                "effective_mtu": 1500,
+                "tags": [],
+                "firmware_version": null,
+                "enabled": true,
+                "vlan": null,
+                "children": [],
+                "params": "",
+                "vendor": null,
+                "links": [],
+                "product": null,
+                "type": "physical",
+                "id": 383,
+                "mac_address": "d0:94:66:3b:7b:2d",
+                "resource_uri": "/MAAS/api/2.0/nodes/axpnhq/interfaces/383/"
+            },
+            {
+                "discovered": null,
+                "parents": [],
+                "name": "enp5s0f1",
+                "system_id": "axpnhq",
+                "effective_mtu": 1500,
+                "tags": [],
+                "firmware_version": null,
+                "enabled": true,
+                "vlan": null,
+                "children": [],
+                "params": "",
+                "vendor": null,
+                "links": [],
+                "product": null,
+                "type": "physical",
+                "id": 382,
+                "mac_address": "f4:e9:d4:bf:fb:52",
+                "resource_uri": "/MAAS/api/2.0/nodes/axpnhq/interfaces/382/"
+            },
+            {
+                "discovered": null,
+                "parents": [],
+                "name": "eno3",
+                "system_id": "axpnhq",
+                "effective_mtu": 1500,
+                "tags": [],
+                "firmware_version": null,
+                "enabled": true,
+                "vlan": null,
+                "children": [],
+                "params": "",
+                "vendor": null,
+                "links": [],
+                "product": null,
+                "type": "physical",
+                "id": 381,
+                "mac_address": "d0:94:66:3b:7b:2c",
+                "resource_uri": "/MAAS/api/2.0/nodes/axpnhq/interfaces/381/"
+            }
+        ],
+        "commissioning_status_name": "Passed",
+        "current_commissioning_result_id": 1751,
+        "cpu_test_status_name": "Unknown",
+        "physicalblockdevice_set": [
+            {
+                "firmware_version": "Unknown",
+                "path": "/dev/disk/by-dname/sda",
+                "name": "sda",
+                "system_id": "axpnhq",
+                "model": "MTFDDAK256TBN",
+                "tags": [
+                    "ssd",
+                    "sata"
+                ],
+                "serial": "18021AEE0940",
+                "block_size": 4096,
+                "partitions": [
+                    {
+                        "uuid": "ea843803-6f6e-449d-a577-c4311c1e8224",
+                        "size": 256053870592,
+                        "bootable": false,
+                        "tags": [],
+                        "path": "/dev/disk/by-dname/sda-part1",
+                        "system_id": "axpnhq",
+                        "used_for": "ext4 formatted filesystem mounted at /",
+                        "filesystem": {
+                            "fstype": "ext4",
+                            "label": "root",
+                            "uuid": "92d49f8d-eef8-4cbb-9ae0-2c91ac450264",
+                            "mount_point": "/",
+                            "mount_options": null
+                        },
+                        "type": "partition",
+                        "id": 361,
+                        "device_id": 25,
+                        "resource_uri": "/MAAS/api/2.0/nodes/axpnhq/blockdevices/25/partition/361"
+                    }
+                ],
+                "used_for": "MBR partitioned with 1 partition",
+                "id_path": "/dev/disk/by-id/wwn-0x500a07511aee0940",
+                "available_size": 0,
+                "used_size": 256059113472,
+                "partition_table_type": "MBR",
+                "storage_pool": null,
+                "uuid": null,
+                "size": 256060514304,
+                "type": "physical",
+                "id": 25,
+                "filesystem": null,
+                "resource_uri": "/MAAS/api/2.0/nodes/axpnhq/blockdevices/25/"
+            }
+        ],
+        "default_gateways": {
+            "ipv4": {
+                "gateway_ip": null,
+                "link_id": null
+            },
+            "ipv6": {
+                "gateway_ip": null,
+                "link_id": null
+            }
+        },
+        "memory": 131068,
+        "cpu_speed": 0,
+        "power_type": "ipmi",
+        "swap_size": null,
+        "virtualblockdevice_set": [],
+        "storage": 256060.51430399998,
+        "owner": "roblox",
+        "cache_sets": [],
+        "ip_addresses": [
+            "209.206.42.11"
+        ],
+        "system_id": "axpnhq",
+        "min_hwe_kernel": "",
+        "power_state": "on",
+        "volume_groups": [],
+        "current_installation_result_id": 14253,
+        "osystem": "ubuntu",
+        "node_type": 0,
+        "boot_interface": {
+            "discovered": [
+                {
+                    "subnet": {
+                        "name": "ac08-sjc1 public",
+                        "vlan": {
+                            "vid": 0,
+                            "mtu": 1500,
+                            "dhcp_on": true,
+                            "external_dhcp": null,
+                            "relay_vlan": null,
+                            "space": "undefined",
+                            "name": "untagged",
+                            "secondary_rack": null,
+                            "fabric_id": 4,
+                            "fabric": "ac08-sjc1",
+                            "id": 5005,
+                            "primary_rack": "qbd6s7",
+                            "resource_uri": "/MAAS/api/2.0/vlans/5005/"
+                        },
+                        "cidr": "209.206.42.0/26",
+                        "rdns_mode": 2,
+                        "gateway_ip": "209.206.42.1",
+                        "dns_servers": [
+                            "10.164.0.48",
+                            "10.164.0.176",
+                            "10.164.0.112",
+                            "10.164.0.251",
+                            "10.164.1.60",
+                            "10.164.1.125"
+                        ],
+                        "allow_dns": true,
+                        "allow_proxy": true,
+                        "active_discovery": false,
+                        "managed": true,
+                        "id": 16,
+                        "space": "undefined",
+                        "resource_uri": "/MAAS/api/2.0/subnets/16/"
+                    },
+                    "ip_address": "209.206.42.11"
+                }
+            ],
+            "parents": [],
+            "name": "enp5s0f0",
+            "system_id": "axpnhq",
+            "effective_mtu": 1500,
+            "tags": [],
+            "firmware_version": null,
+            "enabled": true,
+            "vlan": {
+                "vid": 0,
+                "mtu": 1500,
+                "dhcp_on": true,
+                "external_dhcp": null,
+                "relay_vlan": null,
+                "space": "undefined",
+                "name": "untagged",
+                "secondary_rack": null,
+                "fabric_id": 4,
+                "fabric": "ac08-sjc1",
+                "id": 5005,
+                "primary_rack": "qbd6s7",
+                "resource_uri": "/MAAS/api/2.0/vlans/5005/"
+            },
+            "children": [],
+            "params": {},
+            "vendor": null,
+            "links": [
+                {
+                    "id": 1299,
+                    "mode": "dhcp",
+                    "ip_address": "209.206.42.11",
+                    "subnet": {
+                        "name": "ac08-sjc1 public",
+                        "vlan": {
+                            "vid": 0,
+                            "mtu": 1500,
+                            "dhcp_on": true,
+                            "external_dhcp": null,
+                            "relay_vlan": null,
+                            "space": "undefined",
+                            "name": "untagged",
+                            "secondary_rack": null,
+                            "fabric_id": 4,
+                            "fabric": "ac08-sjc1",
+                            "id": 5005,
+                            "primary_rack": "qbd6s7",
+                            "resource_uri": "/MAAS/api/2.0/vlans/5005/"
+                        },
+                        "cidr": "209.206.42.0/26",
+                        "rdns_mode": 2,
+                        "gateway_ip": "209.206.42.1",
+                        "dns_servers": [
+                            "10.164.0.48",
+                            "10.164.0.176",
+                            "10.164.0.112",
+                            "10.164.0.251",
+                            "10.164.1.60",
+                            "10.164.1.125"
+                        ],
+                        "allow_dns": true,
+                        "allow_proxy": true,
+                        "active_discovery": false,
+                        "managed": true,
+                        "id": 16,
+                        "space": "undefined",
+                        "resource_uri": "/MAAS/api/2.0/subnets/16/"
+                    }
+                }
+            ],
+            "product": null,
+            "type": "physical",
+            "id": 338,
+            "mac_address": "f4:e9:d4:bf:fb:50",
+            "resource_uri": "/MAAS/api/2.0/nodes/axpnhq/interfaces/338/"
+        },
+        "netboot": false,
+        "boot_disk": {
+            "firmware_version": "Unknown",
+            "path": "/dev/disk/by-dname/sda",
+            "name": "sda",
+            "system_id": "axpnhq",
+            "model": "MTFDDAK256TBN",
+            "tags": [
+                "ssd",
+                "sata"
+            ],
+            "serial": "18021AEE0940",
+            "block_size": 4096,
+            "partitions": [
+                {
+                    "uuid": "ea843803-6f6e-449d-a577-c4311c1e8224",
+                    "size": 256053870592,
+                    "bootable": false,
+                    "tags": [],
+                    "path": "/dev/disk/by-dname/sda-part1",
+                    "system_id": "axpnhq",
+                    "used_for": "ext4 formatted filesystem mounted at /",
+                    "filesystem": {
+                        "fstype": "ext4",
+                        "label": "root",
+                        "uuid": "92d49f8d-eef8-4cbb-9ae0-2c91ac450264",
+                        "mount_point": "/",
+                        "mount_options": null
+                    },
+                    "type": "partition",
+                    "id": 361,
+                    "device_id": 25,
+                    "resource_uri": "/MAAS/api/2.0/nodes/axpnhq/blockdevices/25/partition/361"
+                }
+            ],
+            "used_for": "MBR partitioned with 1 partition",
+            "id_path": "/dev/disk/by-id/wwn-0x500a07511aee0940",
+            "available_size": 0,
+            "used_size": 256059113472,
+            "partition_table_type": "MBR",
+            "storage_pool": null,
+            "uuid": null,
+            "size": 256060514304,
+            "type": "physical",
+            "id": 25,
+            "filesystem": null,
+            "resource_uri": "/MAAS/api/2.0/nodes/axpnhq/blockdevices/25/"
+        },
+        "iscsiblockdevice_set": [],
+        "pod": null,
+        "bcaches": [],
+        "resource_uri": "/MAAS/api/2.0/machines/axpnhq/"
+    }
+]


### PR DESCRIPTION
This commit adds support for:
* selecting a specific HWE kernel train
* passing the install_kvm boolean flag to build and register a KVM server (new in MAAS 2.5.x)
* passing the install_rackd boolean flag to build a MAAS rack controller (new in 2.5.x/2.6)

The install_rackd functionality is untested as of this moment but it should work just like install_kvm. There are reportedly some bugs with this flag in the MAAS 2.5.x released but it is supposedly fixed in 2.6.0.
