### PR TITLE
PE-8287: Use gox to build multi-platform releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,13 @@ jobs:
     <<: *make_run
     environment:
       MAKE_COMMAND: ""
+    steps:
+      - store_artifacts:
+          path: ./build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - build/
   tagging:
     docker:
       - image: ubuntu:latest
@@ -50,6 +57,16 @@ jobs:
             NEW_TAG="$VNUM1.$VNUM2.$VNUM3"
             git tag $NEW_TAG
             git push --tags
+  release:
+    docker:
+      - image: cibuilds/github:0.10
+    steps:
+      - attach_workspace:
+          at: ./build
+      - run:
+          name: "Publish Release on GitHub"
+          command: ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} ./build/
+
 workflows:
   version: 2
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
           at: ./build
       - run:
           name: "Publish Release on GitHub"
-          command: ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} ./build/
+          command: ghr -u "${CIRCLE_PROJECT_USERNAME}" -r "${CIRCLE_PROJECT_REPONAME}" -c "${CIRCLE_SHA1}" -t "${GITHUB_PAT}" -delete "${CIRCLE_TAG}" ./build/
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ make_run: &make_run
         name: Packer Run
         command: |
           set -e
-          go build
           make $MAKE_COMMAND
 jobs:
   lint:
@@ -24,6 +23,10 @@ jobs:
     environment:
       MAKE_COMMAND: ""
     steps:
+      - checkout
+      - run:
+          name: Run default Make target
+          command: make
       - store_artifacts:
           path: ./build
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,14 +71,33 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - lint
-      - test
+      - lint:
+          filters:
+            tags:
+              only: /^v.*/
+      - test:
+          filters:
+            tags:
+              only: /^v.*/
       - build:
           requires:
             - lint
             - test
+          filters:
+            tags:
+              only: /^v.*/
       - tagging:
           filters:
             branches:
               only:
                 - master
+            tags:
+              only: /^v.*/
+      - release:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,16 @@ GOGET ?= $(GO) get -u
 GOBIN ?= $(go env GOPATH)/bin
 
 # Build (default target)
-GOBUILD ?= $(GO) build
-BUILD_OPTIONS ?= -mod=readonly
-build:
+GOBUILD ?= gox
+BUILD_OPTIONS ?= -mod=readonly -output="build/terraform-provider-maas_v${CIRCLE_TAG:=}_{{.OS}}_{{.Arch}}"
+build: install_gox
 	$(GOBUILD) $(BUILD_OPTIONS)
 .PHONY: build
 .DEFAULT_GOAL := build
+
+install_gox:
+	command -v gox || go get github.com/mitchellh/gox
+.PHONY: install_gox
 
 # Lint (https://github.com/golangci/golangci-lint)
 LINTER_OPTIONS ?= run# Arguments to golangci-lint


### PR DESCRIPTION
This PR:

- Updates the `build` (default) Make target to install gox if not present and use it to build releases
- Updates the Circle `build` job to upload these artifacts to Circle
- Creates a release job, which sideloads the artifacts from the build job, and creates a Github release with the artifacts. The release job only runs on tags.