### PR TITLE
PO-510 Extra "v" in version numbers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GOBIN ?= $(go env GOPATH)/bin
 
 # Build (default target)
 GOBUILD ?= gox
-BUILD_OPTIONS ?= -mod=readonly -output="build/terraform-provider-maas_v${CIRCLE_TAG:=}_{{.OS}}_{{.Arch}}"
+BUILD_OPTIONS ?= -mod=readonly -output="build/terraform-provider-maas_${CIRCLE_TAG:=}_{{.OS}}_{{.Arch}}"
 build: install_gox
 	$(GOBUILD) $(BUILD_OPTIONS)
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ install_gox:
 # Lint (https://github.com/golangci/golangci-lint)
 LINTER_OPTIONS ?= run# Arguments to golangci-lint
 LINTER_BINARY ?= golangci-lint# Name of the binary of golangci-lint
-LINTER_VERSION ?= 1.23.3# Version of golangci-lint to use in CI
+LINTER_VERSION ?= 1.29.0# Version of golangci-lint to use in CI
 
 lint: install_lint
 	$(LINTER_BINARY) $(LINTER_OPTIONS)


### PR DESCRIPTION
According to the [Terraform docs](https://www.terraform.io/docs/configuration/providers.html#plugin-names-and-versions), the plugin filename should be in the format `terraform-provider-<NAME>_vX.Y.Z`, while we had an extra `v` - `terraform-provider-<NAME>_vvX.Y.Z`. This PR removes that extra `v`.

That being said, the release filenames still have the OS and arch (eg `terraform-provider-maas_v3.0.0_linux_amd64`) because we build for different architectures - a file called `terraform-provider-maas_v3.0.0` is compatible with Terraform's naming scheme, but there can only be one file with that name, and it can only be built for one OS and architecture. Github artifacts doesn't have a concept of pathing afaik, nor do [gox](https://github.com/mitchellh/gox) or CircleCI's included `ghr` [tool](https://github.com/tcnksm/ghr).

Even with this fix, a user would still need to write `${FILE//_$(uname -s)*}` to remove the OS and architecture; I'm not sure how to get around that limitation. Ideas?